### PR TITLE
1.0.9+1.0.10:  bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 #### 1.0.7:  bug fix
 
+- time-inject
+  - fixes that time inject will do a recalculation every 1 ms (Problem can only occurs if the time constraints are used.) #106
+
+- blind-control + clock-time
+  - documentation
+  - i18n
+
+#### 1.0.7:  bug fix
+
 - general
   - added additional caching of sun times calculation to reduce calculation load
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # node-red-contrib-sun-position
 
+#### 1.0.10:  bug fix
+
+- general
+  - next try for #102
+
+- sun-position + moon-position
+  - implements #81 - now it is possible to have `msg.latitude` and `msg.longitude` (or `msg.lat` and `msg.lon`) to override settings in configuration node. The configuration Node still needs to be configured properly.
+
 #### 1.0.9:  bug fix
 
 - general

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,19 @@
 #### 1.0.9:  bug fix
 
 - general
- - fixed #102 again - massive changes in the library with cleanup functions
- -
+  - fixed #102 again - massive changes in the library with cleanup lot of functions
+  - fixed and reworked caching of calculated sunTimes, MoonTimes
+
+- blind-control + clock-time
+  - documentation
+  - if in startup delay, the reason code is set to `NaN` and node state, reason description stated that node is in startup
+  - after startup delay ended default output will be send (due to reason code change)
+
+- clock-time
+  - additional to reason or rule change, the payload will also output on these changes
+    - if type of payload has changed
+    - if payload is of type `string`, `number` or `boolean` and value of the payload has changed
+      - changes on `arrays`, `objects` will not detected
 
 #### 1.0.8:  bug fix
 
@@ -21,25 +32,24 @@
   - added additional caching of sun times calculation to reduce calculation load
 
 - blind-control + clock-time
- - fixed start delay setting causing no output at all
- - i18n, spelling, documentation
+  - fixed start delay setting causing no output at all
+  - i18n, spelling, documentation
 
 #### 1.0.6:  bug fix
 
 - general
- - fixed #102 - nodes calculate wrong sun times
-   - this happend between midnight - TimezoneOffset to midnight
-   - maybe fixes also #98
- - fixed broken rule check for time-span #103
+  - fixed #102 - nodes calculate wrong sun times
+    - this happend between midnight - TimezoneOffset to midnight
+    - maybe fixes also #98
+  - fixed broken rule check for time-span #103
 
 - blind-control + clock-time
- - first implementation of #92 (needs more test)
+  - first implementation of #92 (needs more test)
 
 #### 1.0.5:  bug fix
 
 - blind-control + clock-time
- - add start delay setting where a time can be defined where no output
-
+  - add start delay setting where a time can be defined where no output
 
 #### 1.0.4:  bug fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # node-red-contrib-sun-position
 
-#### 1.0.7:  bug fix
+#### 1.0.9:  bug fix
+
+- general
+ - fixed #102 again - massive changes in the library with cleanup functions
+ -
+
+#### 1.0.8:  bug fix
 
 - time-inject
   - fixes that time inject will do a recalculation every 1 ms (Problem can only occurs if the time constraints are used.) #106

--- a/README.md
+++ b/README.md
@@ -16,54 +16,54 @@ In addition, there is now a blind controller, which can set blind position time 
 
 ![nodes](https://user-images.githubusercontent.com/12692680/70033601-19d46a00-15b0-11ea-9e36-a7843e20ff85.png)
 
-
 ## Table of contents
 
-* [node-red-contrib-sun-position for NodeRED](#node-red-contrib-sun-position-for-nodered)
-  * [Table of contents](#table-of-contents)
-  * [Preconditions](#preconditions)
-  * [Installation](#installation)
-  * [General](#general)
-    * [Saving resources](#saving-resources)
-    * [second based accuracy](#second-based-accuracy)
-  * [Implemented Nodes](#implemented-nodes)
-    * [sun-position](#sun-position)
-      * [sun-position - Node settings](#sun-position---node-settings)
-      * [Node Input](#node-input)
-      * [sun-position - Node Output](#sun-position---node-output)
-    * [moon-position](#moon-position)
-      * [moon-position - Node settings](#moon-position---node-settings)
-      * [moon-position - Node Output](#moon-position---node-output)
-    * [time-inject](#time-inject)
-      * [time-inject - Node settings](#time-inject---node-settings)
-      * [time-inject - Node Input](#time-inject---node-input)
-      * [time-inject - Node Output](#time-inject---node-output)
-      * [time-inject - Node Status](#time-inject---node-status)
-    * [within-time](#within-time)
-      * [within-time - Node settings](#within-time---node-settings)
-    * [time-comp](#time-comp)
-      * [time-comp - Node settings](#time-comp---node-settings)
-    * [time-span](#time-span)
-      * [time-span - Node settings](#time-span---node-settings)
-    * [blind-control](#blind-control)
-    * [clock-timer](#clock-timer)
-    * [Times definitions](#times-definitions)
-      * [sun times](#sun-times)
-        * [remarks](#remarks)
-          * [blue hour](#blue-hour)
-          * [amateurDawn /amateurDusk](#amateurdawn-amateurdusk)
-          * [alternate properties](#alternate-properties)
-      * [moon times](#moon-times)
-      * [message, flow or global property or JSONATA expression](#message-flow-or-global-property-or-jsonata-expression)
-    * [input parse formats](#input-parse-formats)
-    * [output timestamp formats](#output-timestamp-formats)
-    * [output timespan formats](#output-timespan-formats)
-    * [Conditions](#conditions)
-  * [CHANGELOG](#changelog)
-  * [TODO](#todo)
-  * [Support, Bugs and Feedback](#support-bugs-and-feedback)
-  * [LICENSE](#license)
-  * [Other](#other)
+- [node-red-contrib-sun-position for NodeRED](#node-red-contrib-sun-position-for-nodered)
+  - [Table of contents](#table-of-contents)
+  - [Preconditions](#preconditions)
+  - [Installation](#installation)
+  - [General](#general)
+    - [Saving resources](#saving-resources)
+    - [second based accuracy](#second-based-accuracy)
+  - [Implemented Nodes](#implemented-nodes)
+    - [sun-position](#sun-position)
+      - [sun-position - Node settings](#sun-position---node-settings)
+      - [sun-position - Node Input](#sun-position---node-input)
+      - [sun-position - Node Output](#sun-position---node-output)
+    - [moon-position](#moon-position)
+      - [moon-position - Node settings](#moon-position---node-settings)
+      - [moon-position - Node Input](#moon-position---node-input)
+      - [moon-position - Node Output](#moon-position---node-output)
+    - [time-inject](#time-inject)
+      - [time-inject - Node settings](#time-inject---node-settings)
+      - [time-inject - Node Input](#time-inject---node-input)
+      - [time-inject - Node Output](#time-inject---node-output)
+      - [time-inject - Node Status](#time-inject---node-status)
+    - [within-time](#within-time)
+      - [within-time - Node settings](#within-time---node-settings)
+    - [time-comp](#time-comp)
+      - [time-comp - Node settings](#time-comp---node-settings)
+    - [time-span](#time-span)
+      - [time-span - Node settings](#time-span---node-settings)
+    - [blind-control](#blind-control)
+    - [clock-timer](#clock-timer)
+    - [Times definitions](#times-definitions)
+      - [sun times](#sun-times)
+        - [remarks](#remarks)
+          - [blue hour](#blue-hour)
+          - [amateurDawn /amateurDusk](#amateurdawn-amateurdusk)
+          - [alternate properties](#alternate-properties)
+      - [moon times](#moon-times)
+      - [message, flow or global property or JSONATA expression](#message-flow-or-global-property-or-jsonata-expression)
+    - [input parse formats](#input-parse-formats)
+    - [output timestamp formats](#output-timestamp-formats)
+    - [output timespan formats](#output-timespan-formats)
+    - [Conditions](#conditions)
+  - [CHANGELOG](#changelog)
+  - [TODO](#todo)
+  - [Support, Bugs and Feedback](#support-bugs-and-feedback)
+  - [LICENSE](#license)
+  - [Other](#other)
 
 ## Preconditions
 
@@ -109,9 +109,11 @@ The node calculates the current sun position on any input message. This node is 
 * **position container** here you can define multiple lower and upper limits for azimuth. If the calculated value of the azimuth is inside the defined limit the input message will send to the associated output.
 * **Name** name of the Node
 
-#### Node Input
+#### sun-position - Node Input
 
 The Input is for triggering the calculation. If limits are defined the input message will send to the output associated to the limit.
+
+It is possible that the incoming message have properties `msg.latitude` and `msg.longitude` (or `msg.lat` and `msg.lon`) defined to override settings in configuration node. The configuration Node still needs to be configured properly.
 
 #### sun-position - Node Output
 
@@ -165,6 +167,12 @@ The node calculates the current sun position on any input message.
 * **Topic** defines the topic of the first output
 * **position container** here you can define multiple lower and upper limits for azimuth. If the calculated value of the azimuth is inside the defined limit the input message will send to the associated output.
 * **Name** name of the Node
+
+#### moon-position - Node Input
+
+The Input is for triggering the calculation.
+
+It is possible that the incoming message have properties `msg.latitude` and `msg.longitude` (or `msg.lat` and `msg.lon`) defined to override settings in configuration node. The configuration Node still needs to be configured properly.
 
 #### moon-position - Node Output
 
@@ -293,7 +301,7 @@ The output is a message with the defined payload and topic in the settings.
 
 * red  on error
 * green
-  * the color opf the status is green, if the next trigger time is soon (< 36h).
+  * the color of the status is green, if the next trigger time is soon (< 36h).
   * type of the status
     * **dot** The next trigger time is normal time. (But that doesn't mean that an inject really takes place.)
     * **ring** The next trigger time is alternate time. (But that doesn't mean that an inject really takes place.)
@@ -672,14 +680,14 @@ A JSONata expression in the *property* must be always a boolean with value true,
 
 ## CHANGELOG
 
-- see [here the releases at npm](https://github.com/rdmtc/node-red-contrib-sun-position/releases).
-- see [here the changelog of master](https://github.com/rdmtc/node-red-contrib-sun-position/blob/HEAD/CHANGELOG.md)
-- see [here the changelog of dev](https://github.com/rdmtc/node-red-contrib-sun-position/blob/dev/CHANGELOG.md)
+* see [here the releases at npm](https://github.com/rdmtc/node-red-contrib-sun-position/releases).
+* see [here the changelog of master](https://github.com/rdmtc/node-red-contrib-sun-position/blob/HEAD/CHANGELOG.md)
+* see [here the changelog of dev](https://github.com/rdmtc/node-red-contrib-sun-position/blob/dev/CHANGELOG.md)
 
 ## TODO
 
-- [ ] add possibility to select input/output timezone
-- [ ] Add new node time-control as a stripped down node of the blind control with only rules for control other devices like dimmer and thermostats
+* [ ] add possibility to select input/output timezone
+* [ ] Add new node time-control as a stripped down node of the blind control with only rules for control other devices like dimmer and thermostats
 
 ## Support, Bugs and Feedback
 

--- a/blind_control.md
+++ b/blind_control.md
@@ -242,6 +242,7 @@ If the node is configured with two outputs this object is set as the `msg.payloa
 * `blindCtrl` a object will be added add as `msg.blindCtrl` property on single output mode or send as `msg.payload` on slit output mode with the following properties:
   * `blindCtrl.reason` - __object__ - for the reason of the current blind position
     * `blindCtrl.reason.code` - __number__ - representing the reason for the blind position. The possible codes are
+      * **NaN** - start delay is setup and node is in this time
       * **-1** - the rules was not evaluated, maybe override is active
       * **1**  - defined default blind position, because no other rule/condition/behavior
       * **2**  - manual override

--- a/clock_timer.md
+++ b/clock_timer.md
@@ -61,6 +61,17 @@ The node was created out of the desire to be able to use the [blind-control node
 
 ![clock-timer-settings-5](https://user-images.githubusercontent.com/12692680/70744896-fe413000-1d22-11ea-8085-0d37847d74dc.png)
 
+#### special settings
+
+* **output** here is configurable if the node has one single (default) or two outputs. See [Node Output](#node-output) for further details.
+* **auto trigger** Typically the calculation will be triggered by an incoming message or by an expiring timeout from an override. Additionally the node can be configured to have an auto trigger time.
+  * If such a time is configured the node will be trigger a new calculation automatically at the next possible time, taking the following times into account:
+    * a time for a rule or the next rule occurs or expires
+    * the configured time span in the node
+  * To thus in the most cases it makes no sense to enter a short period (less than 15min) of auto trigger time in the configuration, because the node automatically shortens the time if necessary.
+  * Please note that the node cannot react to changes in times that are configured via a context. If for example times or offsets configured by using a flow or global context, the auto trigger would not change the next trigger time.
+* **start delay** Sometimes on node-red start (or flow re deploy) the node should not send any output before the system has settled (contexts are set, incoming messages processed, ...). To thus it is possible to define a delay time. Setting a time will only block the node to send any output until the time has reached to the first output. All calculations still will be made.
+
 ### Node Input
 
 The Input is for triggering the calculation and for setting overwrites of the blind position.
@@ -88,6 +99,7 @@ Useful to know:
   - if additional **exactPriority** is defined, then the message priority must be __equal__ to the existing priority.
 - A message where the topic contains `triggerOnly` or with an property `msg.trigger` which is true can not act as override.
 
+
 ### Node Output
 
 In the enhanced option are configurable if the node has one single (default) or two outputs.
@@ -109,6 +121,7 @@ If the node is configured with two outputs this object is set as the `msg.payloa
 * `timeCtrl` a object will be added add as `msg.timeCtrl` property on single output mode or send as `msg.payload` on slit output mode with the following properties:
   * `timeCtrl.reason` - __object__ - for the reason of the current blind position
     * `timeCtrl.reason.code` - __number__ - representing the reason for the blind position. The possible codes are
+      * **NaN** - start delay is setup and node is in this time
       * **-1** - the rules was not evaluated, maybe override is active
       * **1**  - defined default payload, because no other rule/condition/behavior
       * **2**  - manual override
@@ -157,7 +170,7 @@ If the node is configured with two outputs this object is set as the `msg.payloa
 The node status representing the value of the `timeCtrl.reason.state` of the output.
 The color of the output is as following:
 
-* red - any error
+* red - any error or a start delay is set and node is currently in this time
 * blue - override active
 * grey - payload by rule
 * green - default value

--- a/nodes/blind-control.html
+++ b/nodes/blind-control.html
@@ -1336,7 +1336,7 @@
                         title: node._('blind-control.label.dialogtitle'),
                         autoOpen: false,
                         resizable: true,
-                        height: Math.min(600, $(window).height() * 0.9), // 1024
+                        height: Math.min(750, $(window).height() * 0.9), // 1024
                         width: Math.min(850, $(window).width() * 0.9),
                         modal: true,
                         closeOnEscape: true,

--- a/nodes/blind-control.html
+++ b/nodes/blind-control.html
@@ -692,7 +692,7 @@
                                     result += '</var>';
                                     result += _getOffsetText(node, data.offsetMaxType, data.offsetMaxValue, data.multiplierMax);
                                     if (enh && enh.timeMax) {
-                                        result += ' <i class="fa fa-hand-o-right indent-enh-text" aria-hidden="true"></i>&nbsp;<kbd>' + enh.timeMin.text + '</kbd>';
+                                        result += ' <i class="fa fa-hand-o-right indent-enh-text" aria-hidden="true"></i>&nbsp;<kbd>' + enh.timeMax.text + '</kbd>';
                                     }
                                     result += '</div>';
                                 }
@@ -776,11 +776,21 @@
                                     result += '<div class="indent-time-datelimit"><i class="fa fa-calendar-o" aria-hidden="true"></i> <span>';
                                     result += node._('blind-control.label.ruleTimeLimitStart');
                                     result += '</span> <var>';
-                                    result += (getDateShort(data.timeDateStart) || '01-01');
+                                    if (enh) {
+                                        const year = (new Date()).getFullYear();
+                                        result += data.timeDateStart || year + '-01-01';
+                                    } else {
+                                        result += (getDateShort(data.timeDateStart) || '01-01');
+                                    }
                                     result += '</var> <span> ';
                                     result += node._('blind-control.label.ruleTimeLimitEnd');
                                     result += '</span> <var>';
-                                    result += (getDateShort(data.timeDateEnd) || '12-31');
+                                    if (enh) {
+                                        const year = (new Date()).getFullYear();
+                                        result += data.timeDateEnd || year + '-12-31';
+                                    } else {
+                                        result += (getDateShort(data.timeDateEnd) || '12-31');
+                                    }
                                     result += '</var></div>';
                                 }
                                 result += '</div>';
@@ -809,7 +819,7 @@
                         } catch (err) {
                             console.log(err.message); // eslint-disable-line no-console
                             console.log(err.stack); // eslint-disable-line no-console
-                            result = err.message;
+                            result = 'Error: "' + err.message + '"';
                         }
                         return result;
                     }

--- a/nodes/blind-control.js
+++ b/nodes/blind-control.js
@@ -1125,8 +1125,9 @@ module.exports = function (RED) {
             if (node.level.current === node.blindData.levelTop) {
                 shape = 'dot';
             }
-            if (node.startDelayTime) {
+            if (isNaN(code)) {
                 fill = 'red'; // block
+                shape = 'dot';
             } else if (code <= 3) {
                 fill = 'blue'; // override
             } else if (code === 4 || code === 15 || code === 16) {
@@ -1253,7 +1254,11 @@ module.exports = function (RED) {
                     blindCtrl.level = node.level.current;
                     blindCtrl.levelInverse = node.level.currentInverse;
                 }
-                // node.debug(`result pos=${blindCtrl.level} manual=${node.blindData.overwrite.active} reasoncode=${node.reason.code} description=${node.reason.description}`);
+                if (node.startDelayTime) {
+                    node.reason.code = NaN;
+                    node.reason.state = RED._('blind-control.states.startDelay');
+                    node.reason.description = RED._('blind-control.reasons.startDelay');
+                }
                 setState(blindCtrl);
 
                 let topic = config.topic;
@@ -1273,10 +1278,10 @@ module.exports = function (RED) {
                 }
 
                 if ((!isNaN(node.level.current)) &&
+                    (!isNaN(node.reason.code)) &&
                     ((node.level.current !== previousData.level) ||
                     (node.reason.code !== previousData.reasonCode) ||
-                    (ruleId !== previousData.usedRule)) &&
-                    !node.startDelayTime) {
+                    (ruleId !== previousData.usedRule))) {
                     msg.payload = blindCtrl.level;
                     if (node.outputs > 1) {
                         send([msg, { topic, payload: blindCtrl }]); // node.send([msg, { topic, payload: blindCtrl }]);

--- a/nodes/blind-control.js
+++ b/nodes/blind-control.js
@@ -1157,7 +1157,6 @@ module.exports = function (RED) {
 
                 // node.debug('input ' + util.inspect(msg, { colors: true, compact: 10, breakLength: Infinity })); // Object.getOwnPropertyNames(msg)
                 if (!this.positionConfig) {
-                    // node.error(RED._('node-red-contrib-sun-position/position-config:errors.pos-config'));
                     node.status({
                         fill: 'red',
                         shape: 'dot',

--- a/nodes/clock-timer.html
+++ b/nodes/clock-timer.html
@@ -769,7 +769,7 @@
                         title: node._('clock-timer.label.dialogtitle'),
                         autoOpen: false,
                         resizable: true,
-                        height: Math.min(600, $(window).height() * 0.9), // 1024
+                        height: Math.min(750, $(window).height() * 0.9), // 1024
                         width: Math.min(850, $(window).width() * 0.9),
                         modal: true,
                         closeOnEscape: true,

--- a/nodes/clock-timer.html
+++ b/nodes/clock-timer.html
@@ -430,11 +430,10 @@
                                     result += '</var>';
                                     result += _getOffsetText(node, data.offsetMaxType, data.offsetMaxValue, data.multiplierMax);
                                     if (enh && enh.timeMax) {
-                                        result += ' <i class="fa fa-hand-o-right indent-enh-text" aria-hidden="true"></i>&nbsp;<kbd>' + enh.timeMin.text + '</kbd>';
+                                        result += ' <i class="fa fa-hand-o-right indent-enh-text" aria-hidden="true"></i>&nbsp;<kbd>' + enh.timeMax.text + '</kbd>';
                                     }
                                     result += '</div>';
                                 }
-
                                 if ((data.timeDays && data.timeDays !== '*') || data.timeOnlyEvenDays || data.timeOnlyOddDays) {
                                     result += '<div class="indent-time-days"><i class="fa fa-calendar-o" aria-hidden="true"></i> <span>';
                                     result += node._('clock-timer.label.ruleTimeDays');
@@ -515,11 +514,21 @@
                                     result += '<div class="indent-time-datelimit"><i class="fa fa-calendar-o" aria-hidden="true"></i> <span>';
                                     result += node._('clock-timer.label.ruleTimeLimitStart');
                                     result += '</span> <var>';
-                                    result += (getDateShort(data.timeDateStart) || '01-01');
+                                    if (enh) {
+                                        const year = (new Date()).getFullYear();
+                                        result += data.timeDateStart || year + '-01-01';
+                                    } else {
+                                        result += (getDateShort(data.timeDateStart) || '01-01');
+                                    }
                                     result += '</var> <span> ';
                                     result += node._('clock-timer.label.ruleTimeLimitEnd');
                                     result += '</span> <var>';
-                                    result += (getDateShort(data.timeDateEnd) || '12-31');
+                                    if (enh) {
+                                        const year = (new Date()).getFullYear();
+                                        result += data.timeDateEnd || year + '-12-31';
+                                    } else {
+                                        result += (getDateShort(data.timeDateEnd) || '12-31');
+                                    }
                                     result += '</var></div>';
                                 }
                                 result += '</div>';
@@ -548,7 +557,7 @@
                         } catch (err) {
                             console.log(err.message); // eslint-disable-line no-console
                             console.log(err.stack); // eslint-disable-line no-console
-                            result = 'Error "' + err.message + '"';
+                            result = 'Error: "' + err.message + '"';
                         }
                         return result;
                     }

--- a/nodes/clock-timer.js
+++ b/nodes/clock-timer.js
@@ -416,7 +416,7 @@ module.exports = function (RED) {
         const monthNr = now.getMonth();
         const dayId =  hlp.getDayId(now);
         prepareRules(node, msg, tempData);
-        // node.debug(`checkRules nowNr=${nowNr}, rules.count=${node.rules.count}, rules.lastUntil=${node.rules.lastUntil}`); // {colors:true, compact:10}
+        // node.debug(`checkRules now=${now.toISOString()}, nowNr=${nowNr}, rules.count=${node.rules.count}, rules.lastUntil=${node.rules.lastUntil}`); // {colors:true, compact:10}
 
         const fktCheck = (rule, cmp) => {
             // node.debug('rule ' + util.inspect(rule, {colors:true, compact:10}));
@@ -464,7 +464,7 @@ module.exports = function (RED) {
                 }
             }
             const num = getRuleTimeData(node, msg, rule, now);
-            // node.debug(`pos=${rule.pos} type=${rule.timeOpText} - ${rule.timeValue} - rule.timeData = ${ util.inspect(rule.timeData, { colors: true, compact: 40, breakLength: Infinity }) }`);
+            // node.debug(`pos=${rule.pos} type=${rule.timeOpText} - ${rule.timeValue} - num=${num}- rule.timeData = ${ util.inspect(rule.timeData, { colors: true, compact: 40, breakLength: Infinity }) }`);
             if (dayId === rule.timeData.dayId && num >=0  && cmp(num)) {
                 return rule;
             }
@@ -698,7 +698,6 @@ module.exports = function (RED) {
                 node.debug(`--------- clock-timer - input msg.topic=${msg.topic} msg.payload=${msg.payload}`);
                 // node.debug('input ' + util.inspect(msg, { colors: true, compact: 10, breakLength: Infinity })); // Object.getOwnPropertyNames(msg)
                 if (!this.positionConfig) {
-                    // node.error(RED._('node-red-contrib-sun-position/position-config:errors.pos-config'));
                     node.status({
                         fill: 'red',
                         shape: 'dot',

--- a/nodes/clock-timer.js
+++ b/nodes/clock-timer.js
@@ -697,7 +697,6 @@ module.exports = function (RED) {
 
             try {
                 node.debug(`--------- clock-timer - input msg.topic=${msg.topic} msg.payload=${msg.payload}`);
-                // node.debug('input ' + util.inspect(msg, { colors: true, compact: 10, breakLength: Infinity })); // Object.getOwnPropertyNames(msg)
                 if (!this.positionConfig) {
                     node.status({
                         fill: 'red',
@@ -732,7 +731,7 @@ module.exports = function (RED) {
                 const timeCtrl = {
                     autoTrigger : node.autoTrigger
                 };
-                // node.debug(`start pos=${node.payload.current} manual=${node.timeClockData.overwrite.active} reasoncode=${node.reason.code} description=${node.reason.description}`);
+
                 // check for manual overwrite
                 if (!checkTCPosOverwrite(node, msg, now)) {
                     // calc times:
@@ -747,7 +746,7 @@ module.exports = function (RED) {
                 if (node.startDelayTime) {
                     node.reason.code = NaN;
                     node.reason.state = RED._('clock-timer.states.startDelay');
-                    node.reason.description = RED._('clock-timer.reasons.startDelay');
+                    node.reason.description = RED._('clock-timer.reasons.startDelay', {dateISO:node.startDelayTimeOut.toISOString()});
                 }
                 setState(node.payload.current);
 
@@ -908,6 +907,7 @@ module.exports = function (RED) {
                 } else {
                     rule.timeDays = rule.timeDays.split(',');
                 }
+
                 if (!rule.timeMonths || rule.timeMonths === '*') {
                     rule.timeMonths = null;
                 } else {
@@ -983,28 +983,19 @@ module.exports = function (RED) {
                     node.rules.checkFrom = true;
                 }
             }
-            /* if (node.rules.data) {
-                node.rules.data.sort((a, b) => {
-                    if (a.timeLimited && b.timeLimited) { // both are time limited
-                        const top = (a.timeOp - b.timeOp);
-                        if (top !== 0) { // from/until type different
-                            return top; // from before until
-                        }
-                    }
-                    return a.pos - b.pos;
-                });
-                node.debug('node.rules.data =' + util.inspect(node.rules.data, { colors: true, compact: 10, breakLength: Infinity }));
-            } */
 
             if (node.autoTrigger || (node.startDelayTime)) {
+                const delay = node.startDelayTime || (30000 + Math.floor(Math.random() * 30000)); // 30s - 1min
+                node.startDelayTimeOut = new Date(Date.now() + delay);
                 setTimeout(() => {
                     delete node.startDelayTime;
+                    delete node.startDelayTimeOut;
                     node.emit('input', {
                         topic: 'autoTrigger/triggerOnly/start',
                         payload: 'triggerOnly',
                         triggerOnly: true
                     });
-                }, node.startDelayTime || (20000 + Math.floor(Math.random() * 30000))); // 20s - 50s
+                }, delay);
             }
         }
 

--- a/nodes/lib/suncalc.js
+++ b/nodes/lib/suncalc.js
@@ -48,18 +48,15 @@ const util = require('util'); // eslint-disable-line no-unused-vars
      * get number of days for a date since 2000
      * @param {Date} date date to get days
      * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
-     * @return {number} cont of days
+     * @return {number} count of days
      */
-    function toDays(date, inUTC) {
+    function toDays(date, doUTCShift) {
         if (!isValidDate(date)) {
             console.log(`toDays: given date parameter is invalid!! date=${date}`); // eslint-disable-line no-console
             date = new Date();
-        } else {
-            date = new Date(date);
         }
-
         let ms = date.valueOf();
-        if (inUTC === false) {
+        if (doUTCShift === true) {
             ms = ms + (date.getTimezoneOffset() * 60 * 1000);
         }
         return ((ms / dayMs) + J1970) - J2000;
@@ -636,8 +633,8 @@ const util = require('util'); // eslint-disable-line no-unused-vars
     * @typedef {Object} moontimes
     * @property {Date} rise - a Date object if the moon is rising on the given Date, otherwhise NaN
     * @property {Date} set - a Date object if the moon is setting on the given Date, otherwhise NaN
-    * @property {boolean} [alwaysUp] - is true if the moon in always up, oitherwise property not exists
-    * @property {boolean} [alwaysDown] - is true if the moon in always up, oitherwise property not exists
+    * @property {boolean} alwaysUp - is true if the moon in always up, oitherwise property not exists
+    * @property {boolean} alwaysDown - is true if the moon in always up, oitherwise property not exists
     */
 
     /**
@@ -733,7 +730,16 @@ const util = require('util'); // eslint-disable-line no-unused-vars
         }
 
         if (!rise && !set) {
-            result[ye > 0 ? 'alwaysUp' : 'alwaysDown'] = true;
+            if (ye > 0) {
+                result.alwaysUp = true;
+                result.alwaysDown = false;
+            } else {
+                result.alwaysUp = false;
+                result.alwaysDown = true;
+            }
+        } else {
+            result.alwaysUp = false;
+            result.alwaysDown = false;
         }
         return result;
     };

--- a/nodes/lib/suncalc.js
+++ b/nodes/lib/suncalc.js
@@ -26,40 +26,21 @@ const util = require('util'); // eslint-disable-line no-unused-vars
     const J2000 = 2451545;
 
     /**
-     * checks if a value is a valid Date object
-     * @param {*} d - a value to check
-     * @returns {boolean} returns __true__ if it is a valid Date, otherwhise __false__
-     */
-    function isValidDate(d) {
-        return d instanceof Date && !isNaN(d);
-        // d !== 'Invalid Date' && !isNaN(d)
-    }
-
-    /**
      * convert date from Julian calendar
-     * @param {*} date object to convert
-     * @return {date} result date
+     * @param {number} day nmber in julian calendar to convert
+     * @return {number} result date as unix timestamp
      */
     function fromJulianDay(j) {
-        return new Date((j - J1970) * dayMs);
+        return (j - J1970) * dayMs;
     }
 
     /**
-     * get number of days for a date since 2000
-     * @param {Date} date date to get days
-     * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
+     * get number of days for a dateValue since 2000
+     * @param {number} dateValue date as unix timestamp to get days
      * @return {number} count of days
      */
-    function toDays(date, doUTCShift) {
-        if (!isValidDate(date)) {
-            console.log(`toDays: given date parameter is invalid!! date=${date}`); // eslint-disable-line no-console
-            date = new Date();
-        }
-        let ms = date.valueOf();
-        if (doUTCShift === true) {
-            ms = ms + (date.getTimezoneOffset() * 60 * 1000);
-        }
-        return ((ms / dayMs) + J1970) - J2000;
+    function toDays(dateValue) {
+        return ((dateValue / dayMs) + J1970) - J2000;
     }
 
     // general calculations for position
@@ -185,14 +166,13 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
     /**
      * calculates sun position for a given date and latitude/longitude
-     * @param {Date} date Date object with the  for calculating sun-position
+     * @param {number} dateValue date as unix timestamp for calculating sun-position
      * @param {number} lat latitude for calculating sun-position
      * @param {number} lng longitude for calculating sun-position
-     * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
      * @return {sunposition} result object of sun-position
     */
-    SunCalc.getPosition = function (date, lat, lng, inUTC) {
-        // console.log(`getPosition date=${date.toISOString()}  lat=${lat}, lng=${lng}, inUTC=${inUTC}`);
+    SunCalc.getPosition = function (dateValue, lat, lng) {
+        // console.log(`getPosition dateValue=${dateValue}  lat=${lat}, lng=${lng}`);
         if (isNaN(lat)) {
             throw new Error('latitude missing');
         }
@@ -201,7 +181,7 @@ const util = require('util'); // eslint-disable-line no-unused-vars
         }
         const lw = rad * -lng;
         const phi = rad * lat;
-        const d = toDays(date, inUTC);
+        const d = toDays(dateValue);
         const c = sunCoords(d);
         const H = siderealTime(d, lw) - c.ra;
         const azimuthr = azimuth(H, phi, c.dec);
@@ -364,14 +344,13 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
     /**
      * calculates sun times for a given date and latitude/longitude
-     * @param {Date} date Date object with the  for calculating sun-times
+     * @param {number} dateValue date as unix timestamp for calculating sun-times
      * @param {number} lat latitude for calculating sun-times
      * @param {number} lng longitude for calculating sun-times
-     * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
      * @return {suntimes} result object of sunTime
      */
-    SunCalc.getSunTimes = function (date, lat, lng, inUTC, noDeprecated) {
-        // console.log(`getSunTimes date=${date.toISOString()}  lat=${lat}, lng=${lng}, inUTC=${inUTC}, noDeprecated=${noDeprecated}`);
+    SunCalc.getSunTimes = function (dateValue, lat, lng, noDeprecated) {
+        // console.log(`getSunTimes dateValue=${dateValue}  lat=${lat}, lng=${lng}, noDeprecated=${noDeprecated}`);
         if (isNaN(lat)) {
             throw new Error('latitude missing');
         }
@@ -380,7 +359,7 @@ const util = require('util'); // eslint-disable-line no-unused-vars
         }
         const lw = rad * -lng;
         const phi = rad * lat;
-        const d = toDays(date, inUTC);
+        const d = toDays(dateValue);
         const n = julianCycle(d, lw);
         const ds = approxTransit(0, lw, n);
         const M = solarMeanAnomaly(ds);
@@ -389,12 +368,11 @@ const util = require('util'); // eslint-disable-line no-unused-vars
         const Jnoon = solarTransitJ(ds, M, L);
         const noonVal = fromJulianDay(Jnoon);
         const nadirVal = fromJulianDay(Jnoon + 0.5);
-        // console.log(`getSunTimes ${date.toISOString()} - Jnoon=${Jnoon} - JulianNoon=${noonVal.toISOString()} - JulianNadir=${nadirVal.toISOString()} ds=${ds}, M=${M}, L=${L}, n=${n}, d=${d}, lw=${lw}, phi=${phi}`);
 
         const result = {
             solarNoon: {
-                value: noonVal,
-                ts: noonVal.getTime(),
+                value: new Date(noonVal),
+                ts: noonVal,
                 name: 'solarNoon',
                 // elevation: 90,
                 julian: Jnoon,
@@ -402,8 +380,8 @@ const util = require('util'); // eslint-disable-line no-unused-vars
                 pos: sunTimes.length
             },
             nadir: {
-                value: nadirVal,
-                ts: nadirVal.getTime(),
+                value: new Date(nadirVal),
+                ts: nadirVal,
                 name: 'nadir',
                 // elevation: 270,
                 julian: Jnoon + 0.5,
@@ -433,8 +411,8 @@ const util = require('util'); // eslint-disable-line no-unused-vars
             const v2 = fromJulianDay(Jrise);
 
             result[time[2]] = {
-                value: v1,
-                ts: v1.getTime(),
+                value: new Date(v1),
+                ts: v1,
                 name: time[2],
                 elevation: sa,
                 julian: Jset,
@@ -442,8 +420,8 @@ const util = require('util'); // eslint-disable-line no-unused-vars
                 pos: len + i + 1
             };
             result[time[1]] = {
-                value: v2,
-                ts: v2.getTime(),
+                value: new Date(v2),
+                ts: v2,
                 name: time[1],
                 elevation: sa, // (180 + (sa * -1)),
                 julian: Jrise,
@@ -467,15 +445,14 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
     /**
      * calculates sun times for a given date and latitude/longitude
-     * @param {Date} date Date object with the  for calculating sun-times
+     * @param {number} dateValue date as unix timestamp for calculating sun-times
      * @param {number} lat latitude for calculating sun-times
      * @param {number} lng longitude for calculating sun-times
      * @param {number} elevationAngle sun angle for calculating sun-time
-     * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
      * @return {suntimes} result object of sunTime
-     */
-    SunCalc.getSunTime = function (date, lat, lng, elevationAngle, inUTC) {
-        // console.log(`getSunTime date=${date.toISOString()}  lat=${lat}, lng=${lng}, inUTC=${inUTC}, elevationAngle=${elevationAngle}`);
+     ***
+    SunCalc.getSunTime = function (dateValue, lat, lng, elevationAngle) {
+        // console.log(`getSunTime dateValue=${dateValue}  lat=${lat}, lng=${lng}, elevationAngle=${elevationAngle}`);
         if (isNaN(lat)) {
             throw new Error('latitude missing');
         }
@@ -487,7 +464,7 @@ const util = require('util'); // eslint-disable-line no-unused-vars
         }
         const lw = rad * -lng;
         const phi = rad * lat;
-        const d = toDays(date, inUTC);
+        const d = toDays(dateValue);
         const n = julianCycle(d, lw);
         const ds = approxTransit(0, lw, n);
         const M = solarMeanAnomaly(ds);
@@ -502,19 +479,19 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
         return {
             set: {
-                value: v1,
-                ts: v1.getTime(),
+                value: new Date(v1),
+                ts: v1,
                 elevation: elevationAngle,
                 julian: Jset
             },
             rise: {
-                value: v2,
-                ts: v2.getTime(),
+                value: new Date(v2),
+                ts: v2,
                 elevation: elevationAngle, // (180 + (elevationAngle * -1)),
                 julian: Jrise
             }
         };
-    };
+    }; /* **** */
 
     // moon calculations, based on http://aa.quae.nl/en/reken/hemelpositie.html formulas
 
@@ -547,14 +524,13 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
     /**
      * calculates moon position for a given date and latitude/longitude
-     * @param {Date} date Date object with the  for calculating moon-position
+     * @param {number} dateValue date as unix timestamp for calculating moon-position
      * @param {number} lat latitude for calculating moon-position
      * @param {number} lng longitude for calculating moon-position
-     * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
      * @return {moonposition} result object of moon-position
      */
-    SunCalc.getMoonPosition = function (date, lat, lng, inUTC) {
-        // console.log(`getMoonPosition date=${date.toISOString()}  lat=${lat}, lng=${lng}, inUTC=${inUTC}`);
+    SunCalc.getMoonPosition = function (dateValue, lat, lng) {
+        // console.log(`getMoonPosition dateValue=${dateValue}  lat=${lat}, lng=${lng}`);
         if (isNaN(lat)) {
             throw new Error('latitude missing');
         }
@@ -564,7 +540,7 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
         const lw = rad * -lng;
         const phi = rad * lat;
-        const d = toDays(date, inUTC);
+        const d = toDays(dateValue);
         const c = moonCoords(d);
         const H = siderealTime(d, lw) - c.ra;
         let h = altitude(H, phi, c.dec);
@@ -597,13 +573,12 @@ const util = require('util'); // eslint-disable-line no-unused-vars
      * calculations for illumination parameters of the moon,
      * based on http://idlastro.gsfc.nasa.gov/ftp/pro/astro/mphase.pro formulas and
      * Chapter 48 of "Astronomical Algorithms" 2nd edition by Jean Meeus (Willmann-Bell, Richmond) 1998.
-     * @param {Date} date Date object with the  for calculating moon-illumination
-     * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
+     * @param {number} dateValue date as unix timestamp for calculating moon-illumination
      * @return {moonillumination} result object of moon-illumination
      */
-    SunCalc.getMoonIllumination = function (date, inUTC) {
-        // console.log(`getMoonIllumination date=${date.toISOString()}`);
-        const d = toDays(date, inUTC);
+    SunCalc.getMoonIllumination = function (dateValue) {
+        // console.log(`getMoonIllumination dateValue=${dateValue}`);
+        const d = toDays(dateValue);
         const s = sunCoords(d);
         const m = moonCoords(d);
         const sdist = 149598000;  // distance from Earth to Sun in km
@@ -621,12 +596,12 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
     /**
      * add hours to a date
-     * @param {date} date - date object to add hours
+     * @param {number} dateValue date as unix timestamp to add hours
      * @param {number} h - hours to add
-     * @returns {Date} new Date with added hours
+     * @returns {number} new Date as unix timestamp with added hours
      */
-    function hoursLater(date, h) {
-        return new Date(date.valueOf() + h * dayMs / 24);
+    function hoursLater(dateValue, h) {
+        return dateValue + h * dayMs / 24;
     }
 
     /**
@@ -639,40 +614,28 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
     /**
      * calculations for moon rise/set times are based on http://www.stargazing.net/kepler/moonrise.html article
-     * @param {Date} date Date object with the  for calculating moon-times
+     * @param {number} dateValue date as unix timestamp for calculating moon-times
      * @param {number} lat latitude for calculating moon-times
      * @param {number} lng longitude for calculating moon-times
-     * @param {boolean} [inUTC] defines if the calculation should be in utc or local time (default is UTC)
      * @return {moontimes} result object of sunTime
      */
-    SunCalc.getMoonTimes = function (date, lat, lng, inUTC) {
+    SunCalc.getMoonTimes = function (dateValue, lat, lng) {
         if (isNaN(lat)) {
             throw new Error('latitude missing');
         }
         if (isNaN(lng)) {
             throw new Error('longitude missing');
         }
-        if (!isValidDate(date)) {
-            console.log(`getMoonTimes: given date parameter is invalid!! date=${date}`); // eslint-disable-line no-console
-            date = new Date();
-        }
-
-        const t = new Date(date);
-        if (inUTC === false) {
-            t.setHours(0, 0, 0, 0);
-        } else {
-            t.setUTCHours(0, 0, 0, 0);
-        }
-        // console.log(`getMoonTimes lat=${lat} lng=${lng} inUTC=${inUTC} date=${date} t=${t}`);
+        // console.log(`getMoonTimes lat=${lat} lng=${lng} dateValue=${dateValue} t=${t}`);
 
         const hc = 0.133 * rad;
-        let h0 = SunCalc.getMoonPosition(t, lat, lng).altitude - hc;
+        let h0 = SunCalc.getMoonPosition(dateValue, lat, lng).altitude - hc;
         let rise; let set; let ye; let d; let roots; let x1; let x2; let dx;
 
         // go in 2-hour chunks, each time seeing if a 3-point quadratic curve crosses zero (which means rise or set)
         for (let i = 1; i <= 26; i += 2) {
-            const h1 = SunCalc.getMoonPosition(hoursLater(t, i), lat, lng).altitude - hc;
-            const h2 = SunCalc.getMoonPosition(hoursLater(t, i + 1), lat, lng).altitude - hc;
+            const h1 = SunCalc.getMoonPosition(hoursLater(dateValue, i), lat, lng).altitude - hc;
+            const h2 = SunCalc.getMoonPosition(hoursLater(dateValue, i + 1), lat, lng).altitude - hc;
 
             const a = (h0 + h2) / 2 - h1;
             const b = (h2 - h0) / 2;
@@ -718,13 +681,13 @@ const util = require('util'); // eslint-disable-line no-unused-vars
 
         const result = {};
         if (rise) {
-            result.rise = hoursLater(t, rise);
+            result.rise = new Date(hoursLater(dateValue, rise));
         } else {
             result.rise = NaN;
         }
 
         if (set) {
-            result.set = hoursLater(t, set);
+            result.set = new Date(hoursLater(dateValue, set));
         } else {
             result.set = NaN;
         }

--- a/nodes/locales/de/blind-control.json
+++ b/nodes/locales/de/blind-control.json
@@ -168,7 +168,8 @@
 			"sunInWinMax": "Die Sonne scheint ins Fenster und die maximale Rollladenposition ist gesetzt",
 			"sunNotInWinMin": "Die Sonne scheint nicht ins Fenster und die minimale Rollladenposition ist gesetzt",
 			"ruleMin": "__org__ (__level__ ist unter minimum) [__number__] __name__",
-			"ruleMax": "__org__ (__level__ ist über maximum) [__number__] __name__"
+			"ruleMax": "__org__ (__level__ ist über maximum) [__number__] __name__",
+			"startDelay": "verzögerter Start bis __dateISO__"
 		},
 		"states": {
 			"overwriteNoExpire": "überschrieben [Prio=__prio__]",
@@ -189,7 +190,8 @@
 			"sunInWinMax": "Sonne scheint ins Fenster (max)",
 			"sunNotInWinMin": "Sonne scheint nicht ins Fenster (min)",
 			"ruleMin": "__org__ [min rule __number__]",
-			"ruleMax": "__org__ [max rule __number__]"
+			"ruleMax": "__org__ [max rule __number__]",
+			"startDelay": "verzögerter Start"
 		},
 		"errors": {
 			"warning": "Warnung: __message__",

--- a/nodes/locales/de/clock-timer.json
+++ b/nodes/locales/de/clock-timer.json
@@ -95,7 +95,8 @@
 			"ruleTimeCond": "Position durch Zeit Regel __timeOp__ __timeLocal__ und Bedingung __text__ [rule __number__]",
 			"rule": "Position durch feste Regel __number__",
 			"ruleMin": "__org__ (__level__ ist unter minimum) [__number__] __name__",
-			"ruleMax": "__org__ (__level__ ist über maximum) [__number__] __name__"
+			"ruleMax": "__org__ (__level__ ist über maximum) [__number__] __name__",
+			"startDelay": "verzögerter Start bis __dateISO__"
 		},
 		"states": {
 			"overwriteNoExpire": "überschrieben [Prio=__prio__]",
@@ -106,7 +107,8 @@
 			"ruleTimeCond": "__timeOp__ __timeLocal__ + cond __operatorText__ [rule __number__]",
 			"rule": "durch feste Regel __number__",
 			"ruleMin": "__org__ [min rule __number__]",
-			"ruleMax": "__org__ [max rule __number__]"
+			"ruleMax": "__org__ [max rule __number__]",
+			"startDelay": "verzögerter Start"
 		},
 		"errors": {
 			"warning": "Warnung: __message__",

--- a/nodes/locales/en-US/blind-control.json
+++ b/nodes/locales/en-US/blind-control.json
@@ -169,7 +169,7 @@
 			"sunNotInWinMin": "Sun not in window (Level is minimum)",
 			"ruleMin": "__org__ (__level__ is below minimum) [__number__] __name__",
 			"ruleMax": "__org__ (__level__ is above maximum) [__number__] __name__",
-			"startDelay": "node in startup"
+			"startDelay": "node in startup until __dateISO__"
 		},
 		"states": {
 			"overwriteNoExpire": "overwritten [prio=__prio__]",

--- a/nodes/locales/en-US/blind-control.json
+++ b/nodes/locales/en-US/blind-control.json
@@ -168,7 +168,8 @@
 			"sunInWinMax": "Sun in window (Level is maximum)",
 			"sunNotInWinMin": "Sun not in window (Level is minimum)",
 			"ruleMin": "__org__ (__level__ is below minimum) [__number__] __name__",
-			"ruleMax": "__org__ (__level__ is above maximum) [__number__] __name__"
+			"ruleMax": "__org__ (__level__ is above maximum) [__number__] __name__",
+			"startDelay": "node in startup"
 		},
 		"states": {
 			"overwriteNoExpire": "overwritten [prio=__prio__]",
@@ -189,7 +190,8 @@
 			"sunInWinMax": "Sun in window (max)",
 			"sunNotInWinMin": "Sun not in window (min)",
 			"ruleMin": "__org__ [min rule __number__]",
-			"ruleMax": "__org__ [max rule __number__]"
+			"ruleMax": "__org__ [max rule __number__]",
+			"startDelay": "startup"
 		},
 		"errors": {
 			"warning": "Warning: __message__",

--- a/nodes/locales/en-US/clock-timer.json
+++ b/nodes/locales/en-US/clock-timer.json
@@ -95,7 +95,8 @@
 			"ruleTimeCond": "position by time rule __timeOp__ __timeLocal__ and condition __text__ [__number__] __name__",
 			"rule": "position by fixed rule [__number__] __name__",
 			"ruleMin": "__org__ (__level__ is below minimum) [__number__] __name__",
-			"ruleMax": "__org__ (__level__ is above maximum) [__number__] __name__"
+			"ruleMax": "__org__ (__level__ is above maximum) [__number__] __name__",
+			"startDelay": "node in startup"
 		},
 		"states": {
 			"overwriteNoExpire": "overwritten [prio=__prio__]",
@@ -106,7 +107,8 @@
 			"ruleTimeCond": "__timeOp__ __timeLocal__ + cond __operatorText__ [__number__] __name__",
 			"rule": "by fixed rule [__number__] __name__",
 			"ruleMin": "__org__ [min rule __number__]",
-			"ruleMax": "__org__ [max rule __number__]"
+			"ruleMax": "__org__ [max rule __number__]",
+			"startDelay": "startup"
 		},
 		"errors": {
 			"warning": "Warning: __message__",

--- a/nodes/locales/en-US/clock-timer.json
+++ b/nodes/locales/en-US/clock-timer.json
@@ -96,7 +96,7 @@
 			"rule": "position by fixed rule [__number__] __name__",
 			"ruleMin": "__org__ (__level__ is below minimum) [__number__] __name__",
 			"ruleMax": "__org__ (__level__ is above maximum) [__number__] __name__",
-			"startDelay": "node in startup"
+			"startDelay": "node in startup until __dateISO__"
 		},
 		"states": {
 			"overwriteNoExpire": "overwritten [prio=__prio__]",

--- a/nodes/moon-position.js
+++ b/nodes/moon-position.js
@@ -32,7 +32,6 @@ module.exports = function (RED) {
                 const now = hlp.getNowTimeStamp(this, msg);
 
                 if (!this.positionConfig) {
-                    // node.error(RED._('node-red-contrib-sun-position/position-config:errors.pos-config'));
                     node.status({
                         fill: 'red',
                         shape: 'dot',

--- a/nodes/moon-position.js
+++ b/nodes/moon-position.js
@@ -42,7 +42,7 @@ module.exports = function (RED) {
                 }
                 const ports = new Array(this.rules.length);
                 ports[0] = RED.util.cloneMessage(msg);
-                ports[0].payload = this.positionConfig.getMoonCalc(now,false);
+                ports[0].payload = this.positionConfig.getMoonCalc(now,false, msg.latitude || msg.lat,  msg.longitude || msg.lon);
                 ports[0].topic = this.topic;
                 if (!ports[0].payload.azimuth) {
                     // this.error('Azimuth could not calculated!');

--- a/nodes/sun-position.js
+++ b/nodes/sun-position.js
@@ -52,7 +52,7 @@ module.exports = function (RED) {
                 const ports = new Array(this.rules.length);
 
                 ports[0] = RED.util.cloneMessage(msg);
-                ports[0].payload = this.positionConfig.getSunCalc(now, true, false);
+                ports[0].payload = this.positionConfig.getSunCalc(now, true, false, msg.latitude || msg.lat,  msg.longitude || msg.lon);
                 ports[0].topic = this.topic;
                 if (!ports[0].payload.azimuth) {
                     // this.error('Azimuth could not calculated!');
@@ -71,7 +71,9 @@ module.exports = function (RED) {
                         offsetType : node.startOffsetType,
                         offset : node.startOffset,
                         multiplier : node.startOffsetMultiplier,
-                        now
+                        now,
+                        latitude: msg.latitude || msg.lat,
+                        longitude: msg.longitude || msg.lon
                     });
 
                     node.debug('startTime: ' + util.inspect(startTime, { colors: true, compact: 10, breakLength: Infinity }));
@@ -92,7 +94,9 @@ module.exports = function (RED) {
                         offsetType : node.endOffsetType,
                         offset : node.endOffset,
                         multiplier : node.endOffsetMultiplier,
-                        now
+                        now,
+                        latitude: msg.latitude || msg.lat,
+                        longitude: msg.longitude || msg.lon
                     });
 
                     node.debug('endTime: ' + util.inspect(endTime, { colors: true, compact: 10, breakLength: Infinity }));

--- a/nodes/sun-position.js
+++ b/nodes/sun-position.js
@@ -41,7 +41,6 @@ module.exports = function (RED) {
                 const now = hlp.getNowTimeStamp(this, msg);
 
                 if (!this.positionConfig) {
-                    // node.error(RED._('node-red-contrib-sun-position/position-config:errors.pos-config'));
                     node.status({
                         fill: 'red',
                         shape: 'dot',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "NodeRED nodes to get sun and moon position",
   "keywords": [
     "node-red",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "NodeRED nodes to get sun and moon position",
   "keywords": [
     "node-red",


### PR DESCRIPTION
- general
  - fixed #102 again - massive changes in the library with cleanup lot of functions
  - fixed and reworked caching of calculated sunTimes, MoonTimes

- blind-control + clock-time
  - documentation
  - if in startup delay, the reason code is set to `NaN` and node state, reason description stated that node is in startup
  - after startup delay ended default output will be send (due to reason code change)

- clock-time
  - additional to reason or rule change, the payload will also output on these changes
    - if type of payload has changed
    - if payload is of type `string`, `number` or `boolean` and value of the payload has changed
      - changes on `arrays`, `objects` will not detected

- sun-position + moon-position
  - implements #81 - now it is possible to have `msg.latitude` and `msg.longitude` (or `msg.lat` and `msg.lon`) to override settings in configuration node. The configuration Node still needs to be configured properly.