### PR TITLE
new version 1.0.16:  BugFix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # node-red-contrib-sun-position
 
+#### 1.0.16:  BugFix
+
+- general
+  - fix #119
+    - if a positive offset is used the next time was calculated wrong
+
+- blind-control + clock-time
+  - fix #128 for blind-control + clock-time
+    - with #127 the also overrides with a priority higher than `0` will be expire. The documentation is changed to reflect this.
+  - fixed problem that an override can not set as not expiring
+  - fixed state text and level output if level-value of -1 is used
+
 #### 1.0.15:  BugFix + maintenance
 
 - blind-control + clock-time

--- a/blind_control.md
+++ b/blind_control.md
@@ -209,10 +209,10 @@ The Input is for triggering the calculation and for setting overwrites of the bl
   - or when the `msg.topic` contains`prio`, `privilege` or `alarm`  and the value of `msg.payload` is a valid numeric value
   - A `boolean` value `true` is considered as numeric `1`
   - a higher number is a higher priority. So prio 1 is the lowest priority
-- **expire** (optional) Enables to define an override as automatically expiring. As default value for overrides of priority `0` the value in the settings is be used. Overrides with a priority higher than `0` will not expire by default.
+- **expire** (optional) Enables to define an override as automatically expiring. As default value the value in the settings is be used.
   - A message property `msg.expire` or `msg.payload.expire`
   - or when the `msg.topic` contains `expire` and the value of `msg.payload` is a valid numeric value
-  - The value must be a time in milliseconds which is greater than 100. Otherwise the override will be set to not expiring.
+  - The value must be a time in milliseconds which is greater than 0. Otherwise the override will be set to not expiring.
   - If an override is already active a new message with **expire** can change the existing expire behavior if the **priority** of the existing override allows this.
 
 Useful to know:

--- a/clock_timer.md
+++ b/clock_timer.md
@@ -93,7 +93,7 @@ The Input is for triggering the calculation and for setting overwrites of the bl
   - A message property  `msg.prio`, `msg.priority` or `msg.privilege` with a valid numeric value.
   - A `boolean` value `true` is considered as numeric `1`.
   - A higher number is a higher priority. So prio 1 is the lowest priority.
-- **expire** (optional) Enables to define an override as automatically expiring. As default value for overrides of priority `0` the value in the settings is be used. Overrides with a priority higher than `0` will not expire by default.
+- **expire** (optional) Enables to define an override as automatically expiring. As default value the value in the settings is be used.
   - A message property `msg.expire`
   - The value must be a time in milliseconds which is greater than 100. Otherwise the override will be set to not expiring.
   - If an override is already active a new message with **expire** can change the existing expire behavior if the **priority** of the existing override allows this.

--- a/nodes/blind-control.js
+++ b/nodes/blind-control.js
@@ -471,7 +471,7 @@ module.exports = function (RED) {
                 // priook
                 // no expiring on prio change or no existing expiring
                 node.debug(`no expire defined, using default or will not expire`);
-                setExpiringOverwrite(node, dNow, NaN, 'no expire defined');
+                setExpiringOverwrite(node, dNow, NaN, 'no special expire defined');
             }
             if (nPrio > 0) {
                 node.blindData.overwrite.priority = nPrio;

--- a/nodes/clock-timer.js
+++ b/nodes/clock-timer.js
@@ -91,7 +91,7 @@ module.exports = function (RED) {
 
         if (!node.timeClockData.overwrite.expires) {
             node.log(`Overwrite is set which never expire (${reason})`);
-            node.debug(`expireNever expire=${dExpire}ms ${  typeof dExpire  } - isNaN=${  isNaN(dExpire)  } - finite=${  !isFinite(dExpire)  } - min=${  dExpire < 100} state=${String(node.timeClockData.overwrite.expires)}`);
+            node.debug(`expireNever expire=${dExpire}ms ${  typeof dExpire  } - isNaN=${  isNaN(dExpire)  } - finite=${  !isFinite(dExpire)  } - min=${  dExpire < 100}`);
             delete node.timeClockData.overwrite.expireTs;
             delete node.timeClockData.overwrite.expireDate;
             return;
@@ -193,6 +193,7 @@ module.exports = function (RED) {
         // if (node.timeClockData.overwrite.active && (node.timeClockData.overwrite.priority > 0) && (node.timeClockData.overwrite.priority > prio)) {
             // node.debug(`overwrite exit true node.timeClockData.overwrite.active=${node.timeClockData.overwrite.active}, prio=${nPrio}, node.timeClockData.overwrite.priority=${node.timeClockData.overwrite.priority}`);
             // if active, the prio must be 0 or given with same or higher as current overwrite otherwise this will not work
+            node.debug(`do not check any overwrite, priority of message ${nPrio} not matches current overwrite priority ${node.blindData.overwrite.priority}`);
             return setOverwriteReason(node);
         }
         const onlyTrigger = hlp.getMsgBoolValue(msg, ['trigger', 'noOverwrite'], ['triggerOnly', 'noOverwrite']);
@@ -210,7 +211,10 @@ module.exports = function (RED) {
             }
         }
 
-        const nExpire = hlp.getMsgNumberValue(msg, 'expire');
+        let nExpire = hlp.getMsgNumberValue(msg, 'expire');
+        if (msg.topic && String(msg.topic).includes('noExpir')) {
+            nExpire = -1;
+        }
         if (!overrideData && node.timeClockData.overwrite.active) {
             node.debug(`overwrite active, check of prio=${nPrio} or nExpire=${nExpire}`);
             if (Number.isFinite(nExpire)) {
@@ -240,7 +244,7 @@ module.exports = function (RED) {
                 // priook
                 // no expiring on prio change or no existing expiring
                 node.debug(`no expire defined, using default or will not expire`);
-                setExpiringOverwrite(node, dNow, NaN, 'no expire defined');
+                setExpiringOverwrite(node, dNow, NaN, 'no special expire defined');
             }
             if (nPrio > 0) {
                 node.timeClockData.overwrite.priority = nPrio;

--- a/nodes/lib/dateTimeHelper.js
+++ b/nodes/lib/dateTimeHelper.js
@@ -638,7 +638,7 @@ function isValidDate(d) {
  */
 function addOffset(d, offset, multiplier) {
     if (offset && !isNaN(offset) && offset !== 0) {
-        if (offset !== 0 && multiplier > 0) {
+        if (multiplier > 0) {
             return new Date(d.getTime() + Math.floor(offset * multiplier));
         } else if (multiplier === -1) {
             d.setMonth(Math.floor(d.getMonth() + offset));

--- a/nodes/position-config.js
+++ b/nodes/position-config.js
@@ -712,7 +712,7 @@ module.exports = function (RED) {
                 fix: true
             };
             let dNow = new Date(data.now);
-            if (!hlp.isValidDate(dNow)) { dNow = new Date(); _srcNode.debug('given date Parameter ' + data.now + ' is invalid!!');}
+            if (!hlp.isValidDate(dNow)) { dNow = new Date(); _srcNode.debug('getTimeProp: Date parameter not given or date Parameter ' + data.now + ' is invalid!!');}
             try {
                 if (data.type === '' || data.type === 'none' || data.type === null || typeof data.type === 'undefined') {
                     result.error = 'wrong type "' + data.type + '"="' + data.value+'"';

--- a/nodes/position-config.js
+++ b/nodes/position-config.js
@@ -202,6 +202,7 @@ module.exports = function (RED) {
          * @return {timeresult|erroresult} result object of sunTime
          */
         getSunTimeByName(dNow, value, offset, multiplier, limit, latitude, longitude) {
+            // this.debug('getSunTimeByName dNow=' + dNow + ' limit=' + util.inspect(limit, { colors: true, compact: 10, breakLength: Infinity }));
             let result;
             const dayId = hlp.getDayId(dNow); // this._getUTCDayId(dNow);
             if (latitude && longitude) {
@@ -240,7 +241,7 @@ module.exports = function (RED) {
             result.value = hlp.addOffset(new Date(result.value), offset, multiplier);
             if (limit.next && result.value.getTime() <= dNow.getTime()) {
                 if (dayId === this.cache.sunTimesToday.dayId) {
-                    result = Object.assign(result, this.cache.sunTimesTomorrow[value]);
+                    result = Object.assign({}, this.cache.sunTimesTomorrow.times[value]);
                     result.value = hlp.addOffset(new Date(result.value), offset, multiplier);
                 }
                 const datebase = new Date(dNow);
@@ -263,6 +264,7 @@ module.exports = function (RED) {
                     result.error = 'No valid day of week found!';
                 }
             }
+
             if (limit.months && (limit.months !== '*') && (limit.months !== '')) {
                 const monthx = hlp.calcMonthOffset(limit.months, result.value.getMonth());
                 if (monthx > 0) {
@@ -1217,15 +1219,15 @@ module.exports = function (RED) {
         _sunTimesRefresh(todayValue, dayId) {
             this._checkCoordinates();
             if (this.cache.sunTimesToday.dayId === (dayId + 1)) {
-                this.cache.sunTimesToday.dayId = this.cache.sunTimesTomorrow.dayId;
                 this.cache.sunTimesToday.times = this.cache.sunTimesTomorrow.times;
                 this.cache.sunTimesToday.sunPosAtSolarNoon = this.cache.sunTimesTomorrow.sunPosAtSolarNoon;
-                this.cache.sunTimesTomorrow = {};
+                this.cache.sunTimesToday.dayId = this.cache.sunTimesTomorrow.dayId;
             } else {
-                this.cache.sunTimesToday.dayId = dayId;
                 this.cache.sunTimesToday.times = sunCalc.getSunTimes(todayValue, this.latitude, this.longitude);
                 this.cache.sunTimesToday.sunPosAtSolarNoon = sunCalc.getPosition(this.cache.sunTimesToday.times.solarNoon.value.valueOf(), this.latitude, this.longitude);
+                this.cache.sunTimesToday.dayId = dayId;
             }
+            this.cache.sunTimesTomorrow = {};
             this.cache.sunTimesTomorrow.times = sunCalc.getSunTimes(todayValue + dayMs, this.latitude, this.longitude);
             this.cache.sunTimesTomorrow.sunPosAtSolarNoon = sunCalc.getPosition(this.cache.sunTimesTomorrow.times.solarNoon.value.valueOf(), this.latitude, this.longitude);
             this.cache.sunTimesTomorrow.dayId = (dayId + 1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -541,9 +541,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-21.0.0.tgz",
-      "integrity": "sha512-CdLGe2oyw5YAX9rxq9bVz7H2PK+r8PVwdGuvYGMBstpbVD/66yUAgRFQRsJwAsRKLmReo58Lw1jFdNcxdOc4eg==",
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-22.1.0.tgz",
+      "integrity": "sha512-54NdbICM7KrxsGUqQsev9aIMqPXyvyBx2218Qcm0TQ16P9CtBI+YY4hayJR6adrxlq4Ej0JLpgfUXWaQVFqmQg==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.7.2",
@@ -564,13 +564,13 @@
       }
     },
     "eslint-plugin-json": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-2.1.0.tgz",
-      "integrity": "sha512-Qxy3JQVRb/Qh1RdJsg+LXhMLPGp8rTiEktpgKZPMOwJTTXe56zLCrazfdPZIDctETVbR/YFk0y1dSsVcKXu6Jg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-2.1.1.tgz",
+      "integrity": "sha512-Ktsab8ij33V2KFLhh4alC1FYztdmbV32DeMZYYUCZm4kKLW1s4DrleKKgtbAHSJsmshCK5QGOZtfyc2r3jCRsg==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.15",
-        "vscode-json-languageservice": "^3.4.12"
+        "vscode-json-languageservice": "^3.5.1"
       }
     },
     "eslint-plugin-node": {
@@ -1238,9 +1238,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
@@ -1250,6 +1250,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "ms": {
@@ -1989,9 +1997,9 @@
       "dev": true
     },
     "vscode-nls": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.1.tgz",
-      "integrity": "sha512-4R+2UoUUU/LdnMnFjePxfLqNhBS8lrAFyX7pjb2ud/lqDkrUavFUTcG7wR0HBZFakae0Q6KLBFjMS6W93F403A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-4.1.2.tgz",
+      "integrity": "sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==",
       "dev": true
     },
     "vscode-uri": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "NodeRED nodes to get sun and moon position",
   "keywords": [
     "node-red",
@@ -98,7 +98,7 @@
     "eslint-plugin-jsdoc": "^22.1.0",
     "eslint-plugin-json": "^2.1.1",
     "eslint-plugin-node": "^11.0.0",
-    "minimist": ">=1.2.2"
+    "minimist": ">=1.2.5"
   },
   "disabledSettings": {
     "devDependencies-disabled": {


### PR DESCRIPTION

- general
  - fix #119
    - if a positive offset is used the next time was calculated wrong

- blind-control + clock-time
  - fix #128 for blind-control + clock-time
    - with #127 the also overrides with a priority higher than `0` will be expire. The documentation is changed to reflect this.
  - fixed problem that an override can not set as not expiring
  - fixed state text and level output if level-value of -1 is used