### PR TITLE
Ensure input error text is readable on dark themes

### DIFF
--- a/nodes/blind-control.html
+++ b/nodes/blind-control.html
@@ -2804,6 +2804,7 @@
     .input-error {
         border-color: #d6615f !important;
         background-color: #ffcccc !important;
+        color: #555 !important;
     }
 
     .block-indent2 {

--- a/nodes/clock-timer.html
+++ b/nodes/clock-timer.html
@@ -2124,6 +2124,7 @@
     .input-error {
         border-color: #d6615f !important;
         background-color: #ffcccc !important;
+        color: #555 !important;
     }
 
     .block-indent2 {


### PR DESCRIPTION
When using Node-RED dark themes, the input error text can look like this.

<img width="236" alt="Screen Shot 2020-10-01 at 8 06 56 AM" src="https://user-images.githubusercontent.com/29807944/94809905-48ce8e80-03c1-11eb-9589-4e6675144fbf.png">

This PR solves that issue.