### PR TITLE
Remove .input-error

### DIFF
--- a/nodes/blind-control.html
+++ b/nodes/blind-control.html
@@ -2801,12 +2801,6 @@
         margin-left: 2%; /* 10px; */
         width: 98%
     }
-    .input-error {
-        border-color: #d6615f !important;
-        background-color: #ffcccc !important;
-        color: #555 !important;
-    }
-
     .block-indent2 {
         float: left;
         min-height: 1px;

--- a/nodes/clock-timer.html
+++ b/nodes/clock-timer.html
@@ -2121,12 +2121,6 @@
         margin-left: 10px;
         width: 98%
     }
-    .input-error {
-        border-color: #d6615f !important;
-        background-color: #ffcccc !important;
-        color: #555 !important;
-    }
-
     .block-indent2 {
         float: left;
         min-height: 1px;


### PR DESCRIPTION
Some time after having #195 merged, I noticed that this code is messing with other nodes. For example, the events:state node from [node-red-contrib-home-assistant-websocket](https://github.com/zachowj/node-red-contrib-home-assistant-websocket).

<table>
<tr>
	<td>With node-red-contrib-sun-position installed
	<td>After uninstalling node-red-contrib-sun-position
<tr>
	<td><img width="517" alt="Screen Shot 2021-01-05 at 2 03 56 PM" src="https://user-images.githubusercontent.com/29807944/103688043-3f743580-4f5f-11eb-8fe9-6e1f51d1ae25.png">
	<td><img width="517" alt="Screen Shot 2021-01-05 at 2 03 03 PM" src="https://user-images.githubusercontent.com/29807944/103688055-426f2600-4f5f-11eb-8c7b-2cd294474388.png">
<tr>
	<td><img width="517" alt="Screen Shot 2021-01-05 at 9 38 55 AM" src="https://user-images.githubusercontent.com/29807944/103685810-d3440280-4f5b-11eb-8c01-894ae5b7162e.png">
	<td><img width="517" alt="Screen Shot 2021-01-05 at 9 41 14 AM" src="https://user-images.githubusercontent.com/29807944/103685811-d3dc9900-4f5b-11eb-89fd-fd72ad03cff7.png">
</table>

Since Node-RED already has a default style for that, I suggest removing this customization.