### PR TITLE
1.2.4: maintenance + critical bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,40 @@
 
 Install of a specific Version in Node-Red:
  - change to the installation directory of Node-Red
- - enter the command `npm install node-red-contrib-sun-position@1.2.0`
+ - enter the command `npm install node-red-contrib-sun-position@1.2.3`
 
-Install of a specific Version in a Homematic:
+Install of a specific Version in Redmatic (on a Homematic):
 - logon per ssh
-- enter the commands:
+- enter the commands in the order:
   - `source /usr/local/addons/redmatic/home/.profile`
   - `cd /usr/local/addons/redmatic/var`
-  - `npm install --save --no-package-lock --global-style --save-prefix="~" --production node-red-contrib-sun-position@1.2.0`
+  - `npm install --save --no-package-lock --global-style --save-prefix="~" --production node-red-contrib-sun-position@1.2.3`
+
+This can be also used to go back to an older Version.
+
+#### 1.2.4: maintenance + critical bugfix
+
+- time-span
+  - fixed bug that second operand displayed wrong in config!
+  - fixed critical output bug #240
+
+- blind-control + clock-time
+  - added additional information in the output
+    - last data which contain data from the last evaluation (when the rules was last time evaluated) - #223
+      - for blind-control `msg.blindCtrl.lastEvaluated.sunLevel`, `msg.blindCtrl.lastEvaluated.ruleLevel`, `msg.blindCtrl.lastEvaluated.ruleTopic`, `msg.blindCtrl.lastEvaluated.level`, `msg.blindCtrl.lastEvaluated.ruleId`
+      - for clock-time `msg.timeCtrl.lastEvaluated.payload`, `msg.timeCtrl.lastEvaluated.topic`, `msg.timeCtrl.lastEvaluated.ruleId` `msg.timeCtrl.lastEvaluated.ruleTopic`
+    - `msg.blindCtrl.name` / `msg.timeCtrl.name` which is the name of the node (or the id if no name is given in the config) - #238
+      - this information will be send as `msg.payload.name` to the second output if two outputs are configured
+    - `msg.blindCtrl.id` / `msg.timeCtrl.id` which is the id of the node
+      - this information will be send as `msg.payload.id` to the second output if two outputs are configured
+
+- blind-control only
+  - renamed `msg.resetOnSameValue` to `msg.resetOnSameAsLastValue` parameter to reset existing overwrite if `msg.payload` equals to position (`node.previousData.level`) (#223)
 
 #### 1.2.3:  BugFix
 
 - within-time-switch
-  - fix bug that time limitations does not work #236 upstream of  #192)
+  - fix bug that time limitations does not work #236 upstream of #192)
 
 #### 1.2.2:  BugFix
 

--- a/nodes/position-config.js
+++ b/nodes/position-config.js
@@ -775,10 +775,12 @@ module.exports = function (RED) {
         */
 
         /**
-         * get an formated date prepared for output
-         * @param {Date} dateValue Date value
-         * @param {outPropType} data - a Data object
-         */
+          * get an formated date prepared for output
+          * @param {*} _srcNode - source node for logging
+          * @param {*} [msg] - the message object
+          * @param {Date} dateValue - the source date object which should be formated
+          * @param {outPropType} data - additional formating and control data
+          */
         formatOutDate(_srcNode, msg, dateValue, data) {
             const offsetX = this.getFloatProp(_srcNode, msg, data.offsetType, data.offset, 0, data.offsetCallback, data.noOffsetError);
             const result = hlp.normalizeDate(dateValue, offsetX, data.multiplier, data);

--- a/nodes/time-span.html
+++ b/nodes/time-span.html
@@ -349,7 +349,7 @@
                         }
                     });
 
-                    initCombobox(node, $('#node-input-operand2Formatsel'), $('#node-input-operand2Format'), 'dateParseFormat', 'parseFormats', node.operand1Format, 20);
+                    initCombobox(node, $('#node-input-operand2Formatsel'), $('#node-input-operand2Format'), 'dateParseFormat', 'parseFormats', node.operand2Format, 20);
 
                     const $operand2Multiplier = $('#node-input-operand2OffsetMultiplier');
                     appendOptions(node, $operand2Multiplier, 'multiplier');

--- a/nodes/time-span.js
+++ b/nodes/time-span.js
@@ -316,19 +316,20 @@ module.exports = function (RED) {
         this.results = [];
         config.results.forEach(prop => {
             const propNew = {
-                outType     : prop.pt,
-                outValue    : prop.p,
-                type        : prop.vt,
-                value       : prop.v,
-                format      : prop.f,
-                offsetType  : prop.oT,
-                offset      : prop.o,
-                multiplier  : prop.oM,
-                next        : (typeof prop.next === 'undefined' || prop.next === null || prop.next === true || prop.next === 'true') ? true : false,
-                days        : prop.days,
-                months      : prop.months,
-                onlyEvenDays: prop.onlyEvenDays,
-                onlyOddDays : prop.onlyOddDays
+                outType         : prop.pt,
+                outValue        : prop.p,
+                type            : prop.vt,
+                value           : prop.v,
+                format          : prop.f,
+                offsetType      : prop.oT,
+                offset          : prop.o,
+                multiplier      : prop.oM,
+                outTSFormat     : prop.fTs,
+                next            : (typeof prop.next === 'undefined' || prop.next === null || prop.next === true || prop.next === 'true') ? true : false,
+                days            : prop.days,
+                months          : prop.months,
+                onlyEvenDays    : prop.onlyEvenDays,
+                onlyOddDays     : prop.onlyOddDays
             };
 
             if (this.positionConfig && propNew.type === 'jsonata') {
@@ -388,13 +389,12 @@ module.exports = function (RED) {
                 for (let i = 0; i < node.results.length; i++) {
                     const prop = node.results[i];
                     // node.debug(`prepOutMsg-${i} node.results[${i}]=${util.inspect(prop, { colors: true, compact: 10, breakLength: Infinity })}`);
-
                     let resultObj = null;
-                    if (node.result1Value.type === 'timespan') {
-                        resultObj = getFormattedTimeSpanOut(node, operand1.value, operand2.value, prop.result1TSFormat);
-                    } else if (node.result1Value.type === 'operand1') {
+                    if (prop.type === 'timespan') {
+                        resultObj = getFormattedTimeSpanOut(node, operand1.value, operand2.value, prop.outTSFormat);
+                    } else if (prop.type === 'operand1') {
                         resultObj = node.positionConfig.formatOutDate(this, msg, operand1.value, prop);
-                    } else if (node.result1Value.type === 'operand2') {
+                    } else if (prop.type === 'operand2') {
                         resultObj = node.positionConfig.formatOutDate(this, msg, operand2.value, prop);
                     } else {
                         resultObj = node.positionConfig.getOutDataProp(node, msg, prop, dNow);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -410,9 +410,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.0.0.tgz",
-      "integrity": "sha512-AfGe3gqJlcxyRKUjhLzPTUnEMlVVlWJCAh2N0leJndpMflyh0W7zP09+b6NQHBHk7GyR/JY0bXiSswN3QX9Lhg==",
+      "version": "32.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.0.2.tgz",
+      "integrity": "sha512-zMAJAsq02uWVGrmr6TVlJ2nue0wM/94loWb+0Z/aJcX+oELIet+Z1vtSU9xoSkPaOJE1tpI6CkHgUZfVLKTaJg==",
       "dev": true,
       "requires": {
         "comment-parser": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "NodeRED nodes to get sun and moon position",
   "keywords": [
     "node-red",
@@ -105,7 +105,7 @@
   "devDependencies": {
     "eslint": "^7.20.0",
     "eslint-plugin-html": "^6.1.1",
-    "eslint-plugin-jsdoc": "^32.0.0",
+    "eslint-plugin-jsdoc": "^32.0.2",
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-node": "^11.1.0"
   },


### PR DESCRIPTION
- time-span
  - fixed bug that second operand displayed wrong in config!
  - fixed critical output bug #240

- blind-control + clock-time
  - added additional information in the output
    - last data which contain data from the last evaluation (when the rules was last time evaluated) - #223
      - for blind-control `msg.blindCtrl.lastEvaluated.sunLevel`, `msg.blindCtrl.lastEvaluated.ruleLevel`, `msg.blindCtrl.lastEvaluated.ruleTopic`, `msg.blindCtrl.lastEvaluated.level`, `msg.blindCtrl.lastEvaluated.ruleId`
      - for clock-time `msg.timeCtrl.lastEvaluated.payload`, `msg.timeCtrl.lastEvaluated.topic`, `msg.timeCtrl.lastEvaluated.ruleId` `msg.timeCtrl.lastEvaluated.ruleTopic`
    - `msg.blindCtrl.name` / `msg.timeCtrl.name` which is the name of the node (or the id if no name is given in the config) - #238
      - this information will be send as `msg.payload.name` to the second output if two outputs are configured
    - `msg.blindCtrl.id` / `msg.timeCtrl.id` which is the id of the node
      - this information will be send as `msg.payload.id` to the second output if two outputs are configured

- blind-control only
  - renamed `msg.resetOnSameValue` to `msg.resetOnSameAsLastValue` parameter to reset existing overwrite if `msg.payload` equals to position (`node.previousData.level`) (#223)