### PR TITLE
critical Bugs fixed - beta 14

### DIFF
--- a/nodes/blind-control.html
+++ b/nodes/blind-control.html
@@ -411,7 +411,7 @@
                                 if (propType === 'object' && Array.isArray(parsedProp)) {
                                     propType = 'Array';
                                 }
-                            } catch(e) {
+                            } catch (ex) {
                                 propType = 'invalid';
                             }
                         }
@@ -469,12 +469,6 @@
                 }, 300);
                 $('.rdg-ui-btn').button();
 
-                this.sunControlMode = this.sunControlMode || cModeOff;
-                if (this.sunControlMode === 2 || this.sunControlMode === '2') {
-                    this.sunControlMode = cModeSunPosition;
-                    $('#node-input-sunControlMode').val(cModeSunPosition);
-                }
-
                 const $nodeConfig = $('#node-input-positionConfig');
                 const node = this;
 
@@ -488,6 +482,12 @@
                     scrollable: true,
                     collapsible: true
                 });
+
+                this.sunControlMode = this.sunControlMode || cModeOff;
+                if (this.sunControlMode === 2 || this.sunControlMode === '2') {
+                    this.sunControlMode = cModeSunPosition;
+                    $('#node-input-sunControlMode').val(cModeSunPosition);
+                }
 
                 node.dialogAddData = {};
                 const setup = function(node) {
@@ -2878,7 +2878,11 @@
                         if (node.dialogAddData.timeout) { clearTimeout(node.dialogAddData.timeout); }
                         node.dialogAddData.timeout = setTimeout(() => {
                             delete node.dialogAddData.timeout;
-                            $('#dlg-txt-btctl-rule-descr').html(getRuleDescription(node, selFields, _dialogGetData(), node.dialogAddData));
+                            try {
+                                $('#dlg-txt-btctl-rule-descr').html(getRuleDescription(node, selFields, _dialogGetData(), node.dialogAddData));
+                            } catch (err) {
+                                console.warn('_dialogGenHelpText - maybe too fast:', err.message); // eslint-disable-line no-console
+                            }
                         },1000);
                     }
                     /** load the data from the rule */
@@ -3203,10 +3207,10 @@
                             id: 'blind-control-tab-general',
                             label: this._('blind-control.tabs-label.general'),
                             name: this._('blind-control.tabs-label.general'),
-                            iconClass: 'fa Example of tags fa-tags'
+                            iconClass: 'fa fa-tags'
                         });
                         $nodeConfig.change(() => {
-                            if ($nodeConfig.val() === '_ADD_') {
+                            if ($nodeConfig.val() === '_ADD_' || $nodeConfig.val() === '') {
                                 if (tabs.count() > 1){
                                     tabs.removeTab('blind-control-tab-default');
                                     tabs.removeTab('blind-control-tab-time');
@@ -3220,7 +3224,6 @@
                                     name: this._('blind-control.tabs-label.default'),
                                     iconClass: 'fa fa-sliders'
                                     // icon
-                                    // iconClass
                                     // maximumTabWidth
                                     // pinned
                                     // action
@@ -3248,7 +3251,7 @@
                                     iconClass: 'fa fa-sign-out'
                                 });
                             }
-                            setTimeout(() => { tabs.resize(); },0);
+                            setTimeout(() => { tabs.resize(); }, 0);
                         });
                         $nodeConfig.change();
                     })
@@ -3489,7 +3492,7 @@
         <div id="blind-control-tab-sun-control" style="display:none">
             <!-- sun ######################################################################## -->
             <div class="form-row block-noindent is-to-show-initially">
-                <span data-i18n="[html]node-red-contrib-sun-position/position-config:ruleCtrl..text.sunControlMode" class="row-full-width" style="word-wrap:break-word;"></span>
+                <span data-i18n="[html]node-red-contrib-sun-position/position-config:ruleCtrl.text.sunControlMode" class="row-full-width" style="word-wrap:break-word;"></span>
             </div>
             <div class="form-row block-noindent" data-i18n="[title]blind-control.placeholder.sunControlMode">
                 <label for="node-input-sunControlMode"><i class="fa fa-play-circle"></i> <span data-i18n="blind-control.label.sunControlMode"></span></label>

--- a/nodes/clock-timer.html
+++ b/nodes/clock-timer.html
@@ -2124,7 +2124,11 @@
                         if (node.dialogAddData.timeout) { clearTimeout(node.dialogAddData.timeout); }
                         node.dialogAddData.timeout = setTimeout(() => {
                             delete node.dialogAddData.timeout;
-                            $('#dlg-txt-btctl-rule-descr').html(getRuleDescription(node, selFields, _dialogGetData(), node.dialogAddData));
+                            try {
+                                $('#dlg-txt-btctl-rule-descr').html(getRuleDescription(node, selFields, _dialogGetData(), node.dialogAddData));
+                            } catch (err) {
+                                console.warn('_dialogGenHelpText - maybe too fast:', err.message); // eslint-disable-line no-console
+                            }
                         },1000);
                     }
                     /** load the data from the rule */
@@ -2439,14 +2443,14 @@
                             id: 'clock-timer-tab-general',
                             label: this._('clock-timer.tabs-label.general'),
                             name: this._('clock-timer.tabs-label.general'),
-                            iconClass: 'fa Example of tags fa-tags'
+                            iconClass: 'fa fa-tags'
                         });
                         $nodeConfig.change(() => {
-                            if ($nodeConfig.val() === '_ADD_') {
+                            if ($nodeConfig.val() === '_ADD_' || $nodeConfig.val() === '') {
                                 if (tabs.count() > 1){
-                                    tabs.removeTab('blind-control-tab-default');
-                                    tabs.removeTab('blind-control-tab-time');
-                                    tabs.removeTab('blind-control-tab-output');
+                                    tabs.removeTab('clock-timer-tab-default');
+                                    tabs.removeTab('clock-timer-tab-time');
+                                    tabs.removeTab('clock-timer-tab-output');
                                 }
                             } else if (tabs.count() <= 1) {
                                 tabs.addTab({

--- a/nodes/locales/de/time-inject.json
+++ b/nodes/locales/de/time-inject.json
@@ -18,9 +18,7 @@
             "onceDelay": "Sekunden",
             "fewDays": "ein paar Tage",
             "fewMonths": "ein paar Monate",
-            "and":"und",
             "interval-amount":"feste Anzahl zwischen den Zeitpunkten",
-            "interval-fromStart":"Interval von festem Zeitpunkt",
             "count":"Anzahl",
             "intervalStart":"beginnend von"
         },
@@ -31,6 +29,7 @@
             "property": "Property",
             "propertyThreshold": "schwellwert",
             "payload": "payload der gesendeten Nachricht",
+            "intervalCount":"Anzahl",
             "time": "Zeitpunkt für das Senden der Nachricht",
             "timeOffset": "offset der Zeit",
             "timeAlt": "alternativer Zeitpunkt",

--- a/nodes/locales/en-US/time-inject.json
+++ b/nodes/locales/en-US/time-inject.json
@@ -20,9 +20,8 @@
             "fewDays": "few days",
             "fewMonths": "few months",
             "interval-amount":"fixed number between time",
-            "interval-fromStart":"Interval from defined start",
             "count":"Count",
-            "fromStart":"start from"
+            "intervalStart":"start from"
         },
         "placeholder": {
             "position": "Position",
@@ -31,8 +30,8 @@
             "property": "Property",
             "propertyThreshold": "Threshold",
             "payload": "payload data of the send message",
-            "intervalCount":"",
-            "intervalStart":"",
+            "intervalCount":"count",
+            "intervalStart":"YYYY-MM-DDTHH:mm:ss",
             "time": "time for inject",
             "timeOffset": "offset of time",
             "timeAlt": "alternate time",

--- a/nodes/time-inject.html
+++ b/nodes/time-inject.html
@@ -206,6 +206,8 @@
                     required: false,
                     validate(v) {
                         return (
+                            (v === '') ||
+                            (typeof v === 'undefined') ||
                             (this.injectTypeSelect !== 'interval') ||
                             RED.validators.regex(/^\d{4}-\d{1,2}-\d{1,2}T\d{1,2}:\d{1,2}(:\d{1,2})?(.\d{1,3})?Z?$|^\d{2}-\d{1,2}-\d{1,2}T\d{1,2}:\d{1,2}(:\d{1,2})?(.\d{1,3})?Z?$/)(v)
                         );
@@ -1299,10 +1301,16 @@
                         types: ['num', 'env', 'flow', 'global']
                     }); // intervalCount
 
-                    const dNow = (node.intervalStart) ? parseDate(node.intervalStart) : new Date();
-                    dNow.setMinutes(dNow.getMinutes() - dNow.getTimezoneOffset());
-                    $('#node-myinput-intervalStart').val(dNow.toISOString().slice(0,16));
-                    // TODO: add intervalStart
+                    if (node.intervalStart) {
+                        const d = parseDate(node.intervalStart);
+                        const dateTimeLocalValue = (new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString()).slice(0, -1);
+                        $('#node-myinput-intervalStart').val(dateTimeLocalValue);
+                        const dMax = new Date();
+                        dMax.setFullYear(dMax.getFullYear() + 1);
+                        const dateTimeLocalValueMax = (new Date(dMax.getTime() - dMax.getTimezoneOffset() * 60000).toISOString()).slice(0, -1);
+                        $('#node-myinput-intervalStart').attr('max',dateTimeLocalValueMax);
+
+                    }
                     // #endregion interval
                     // #region time
                     if ($('#node-input-timeOnlyOddDays').prop('checked') && $('#node-input-timeOnlyEvenDays').prop('checked') ) {
@@ -1725,8 +1733,12 @@
             oneditsave() {
                 const node = this;
                 const dvalue = $('#node-myinput-intervalStart').val();
-                const dIvStart = new Date(dvalue);
-                node.intervalStart = dIvStart.toISOString();
+                if (dvalue) {
+                    const dIvStart = Date.parse(dvalue);
+                    node.intervalStart = dIvStart.toISOString();
+                } else {
+                    delete node.intervalStart;
+                }
 
                 node.timeDays = getCheckboxesStr($('#time-inject-timeDays input[type=checkbox]:checked'), 7);
                 node.timeAltDays = getCheckboxesStr($('#time-inject-timeAltDays input[type=checkbox]:checked'), 7);

--- a/nodes/time-inject.js
+++ b/nodes/time-inject.js
@@ -93,7 +93,6 @@ module.exports = function (RED) {
         if (this.injType === tInj.interval) {
             if (config.intervalStart) {
                 this.intervalStart = hlp.isoStringToDate(config.intervalStart);
-                this.intervalStart.setMinutes(this.intervalStart.getMinutes() - this.intervalStart.getTimezoneOffset());
             } else {
                 this.intervalStart = new Date();
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "2.0.0-beta-11",
+  "version": "2.0.0-beta-14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-sun-position",
-  "version": "2.0.0-beta-11",
+  "version": "2.0.0-beta-14",
   "description": "NodeRED nodes to get sun and moon position",
   "keywords": [
     "node-red",


### PR DESCRIPTION
time-inject:
- interval 'start from' field wrong UTC time conversation fixed
- interval 'start from' is now in the default be empty
- interval 'start from' added maximum of now + 1 year

blind-control
- wrong dot cause crash in node-red 1.2.9

clock-timer
- remove of tabs wrong